### PR TITLE
Make `clap` an optional dependency 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ thiserror = "1.0"
 bio = "*"
 rand = "0.8.3"
 fxhash = "*"
-clap = "3"
 partitions = "*"
 num-traits = "*"
 needletail = "*"
@@ -29,6 +28,10 @@ gbdt = "*"
 serde_json = "*"
 statrs = "*"
 
+[dependencies.clap]
+version = "3"
+optional = true
+
 [target.'cfg(target_env = "x86_64")'.dependencies]
 tikv-jemallocator = "*"
 
@@ -37,6 +40,13 @@ assert_cmd = "1.0.1"
 predicates = "1"
 serial_test = "*"
 
+[features]
+cli = ["clap"]
+
+[[bin]]
+name = "skani"
+path = "src/main.rs"
+required-features = ["cli"]
 
 
 [profile.release]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod types;
-pub mod parse;
 pub mod params;
 pub mod chain;
 pub mod file_io;
@@ -15,3 +14,5 @@ pub mod regression;
 
 #[cfg(target_arch = "x86_64")]
 pub mod avx2_seeding;
+#[cfg(feature = "cli")]
+pub mod parse;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,20 +1,13 @@
 use crate::cmd_line::*;
 use crate::params::*;
+use crate::regression;
 use clap::parser::ArgMatches;
 use log::LevelFilter;
 use log::*;
 use std::fs;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
-pub fn use_learned_ani(c: usize, individual_contig_q: bool, individual_contig_r: bool, median: bool, robust: bool) -> bool{
-    let learned_ani;
-    if c >= 70 && !individual_contig_q && !individual_contig_r && !median && !robust{
-        learned_ani = true;
-    } else {
-        learned_ani = false;
-    }
-    learned_ani
-}
+
 pub fn parse_params(matches: &ArgMatches) -> (SketchParams, CommandParams) {
     let mode;
     let matches_subc;
@@ -303,7 +296,7 @@ pub fn parse_params(matches: &ArgMatches) -> (SketchParams, CommandParams) {
             learned_ani = false;
         } else {
             learned_ani_cmd = false;
-            learned_ani = use_learned_ani(c, individual_contig_q, individual_contig_r, robust, median);
+            learned_ani = regression::use_learned_ani(c, individual_contig_q, individual_contig_r, robust, median);
         }
     } else {
         learned_ani_cmd = false;

--- a/src/regression.rs
+++ b/src/regression.rs
@@ -5,6 +5,10 @@ use gbdt::decision_tree::Data;
 use gbdt::gradient_boost::GBDT;
 use log::*;
 
+pub fn use_learned_ani(c: usize, individual_contig_q: bool, individual_contig_r: bool, median: bool, robust: bool) -> bool {
+    c >= 70 && !individual_contig_q && !individual_contig_r && !median && !robust
+}
+
 pub fn get_model(c: usize, learned_ani: bool) -> Option<GBDT>{
     let model: Option<GBDT>;
     if learned_ani {

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,6 @@ use crate::regression;
 use crate::file_io;
 use crate::params::*;
 use crate::screen;
-use crate::parse;
 use crate::types::*;
 use fxhash::FxHashMap;
 use log::*;
@@ -223,7 +222,7 @@ pub fn search(command_params: CommandParams) {
     let mut anis = anis.into_inner().unwrap();
     let learned_ani;
     if !command_params.learned_ani_cmd{
-        learned_ani = parse::use_learned_ani(sketch_params.c, command_params.individual_contig_q, command_params.individual_contig_r, command_params.robust, command_params.median);
+        learned_ani = regression::use_learned_ani(sketch_params.c, command_params.individual_contig_q, command_params.individual_contig_r, command_params.robust, command_params.median);
     }
     else{
         learned_ani = command_params.learned_ani;


### PR DESCRIPTION
Hi Jim,

This PR makes `clap` an optional dependency, only required when building the `skani` binary. 

Since in `pyskani` I'm vendoring the Rust crates for reproducible compilation from source, I have to download the transitive dependencies for `skani` on all platforms. Unfortunately, on Windows, `clap` requires `winapi`, which is a huge crate. I end up with around 130MB of extra dependencies for `clap` which I don't really need for the Python bindings:

![image](https://user-images.githubusercontent.com/8660647/217608917-83ebfb8d-3f67-4a03-923f-af0c330e43b9.png)
