### PR TITLE
Fix output format in triangle mode

### DIFF
--- a/src/file_io.rs
+++ b/src/file_io.rs
@@ -416,7 +416,7 @@ pub fn write_phyllip_matrix(
             write!(&mut af_file, "{}", name).unwrap();
             let end = sketches.len();
             for j in 0..end {
-                let full_cond = (full_matrix && i >= j) || (i > j);
+                let full_cond = full_matrix || (i >= j);
                 if i == j {
                     if full_cond {
                         write!(&mut ani_file, "\t{:.2}", perfect).unwrap();

--- a/src/file_io.rs
+++ b/src/file_io.rs
@@ -416,7 +416,7 @@ pub fn write_phyllip_matrix(
             write!(&mut af_file, "{}", name).unwrap();
             let end = sketches.len();
             for j in 0..end {
-                let full_cond = full_matrix || (i >= j);
+                let full_cond = full_matrix || (i > j);
                 if i == j {
                     if full_cond {
                         write!(&mut ani_file, "\t{:.2}", perfect).unwrap();


### PR DESCRIPTION
In triangle mode, when an output file is provided, skani  generates:
1. A lower triangular matrix without a diagonal by default
2. A lower triangular matrix with a diagonal when --full-matrix is provided

IMO, the correct behaviour should be:
1. A lower triangular matrix with a diagonal by default
2. A full matrix when --full-matrix is provided

What do you think?